### PR TITLE
Allow companies to be deleted

### DIFF
--- a/lib/intercom/service/company.rb
+++ b/lib/intercom/service/company.rb
@@ -1,4 +1,5 @@
 require 'intercom/service/base_service'
+require 'intercom/api_operations/delete'
 require 'intercom/api_operations/list'
 require 'intercom/api_operations/scroll'
 require 'intercom/api_operations/find'
@@ -11,6 +12,7 @@ require 'intercom/extended_api_operations/segments'
 module Intercom
   module Service
     class Company < BaseService
+      include ApiOperations::Delete
       include ApiOperations::Find
       include ApiOperations::FindAll
       include ApiOperations::Load

--- a/spec/unit/intercom/company_spec.rb
+++ b/spec/unit/intercom/company_spec.rb
@@ -35,4 +35,10 @@ describe Intercom::Company do
     _(proxy.url).must_equal '/companies/1/contacts'
     _(proxy.resource_class).must_equal Intercom::Contact
   end
+
+  it "deletes a company" do
+    company = Intercom::Company.new("id" => "1")
+    client.expects(:delete).with("/companies/1", {}).returns(test_company)
+    client.companies.delete(company)
+  end
 end


### PR DESCRIPTION
#### Why?

Intercom has supported deleting companies since [API v2.0](https://developers.intercom.com/intercom-api-reference/v2.0/reference#delete-a-company). My app needs to be able to delete company information from Intercom and this would simplify my life! :pray: 

#### How?

I leveraged the existing `delete` API operation and simply added it to the `company` service. Now you can call:

```ruby
client.companies.delete(company)
```
